### PR TITLE
Update Dockerfile for libssl3 and libcrypto3 CVE's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 FROM alpine:3.18
 
-RUN apk update && apk add "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4" && rm -rf /var/cache/apt/*
+RUN apk update && apk add "libcrypto3>=3.1.1-r0" "libssl3>=3.1.1-r0" && rm -rf /var/cache/apt/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns


### PR DESCRIPTION
Our Aquasec tool reported below High Vulnarability in libssl3:3.1.0-r4 and libcrypto3:3.1.0-r4. CVE's -
CVE-2023-2650

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Our Aquasec tool reported below High Vulnarability in libssl3:3.1.0-r4 and libcrypto3:3.1.0-r4. CVE's -
CVE-2023-2650
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE
This is fixed in 3.1.1-r0 so anything greater than this version is fine, thats why updating this to latest.
**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
